### PR TITLE
Fix sponsor list too wide for narrow screens

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -19,7 +19,7 @@ main {
 
     li {
         display: inline-block;
-        margin: 0 $small-spacing $base-spacing;
+        padding: 0 $small-spacing $base-spacing;
         width: 100%;
         vertical-align: middle;
         @include media($large-viewport) {


### PR DESCRIPTION
Combining 100% width with margins results in boxes wider than their parent, causing unpleasant scrollbars on narrow screens. This removes the unwanted white column on the right-hand side on both smartphones and tablets.
